### PR TITLE
tuzigiriじゃー

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN ./gradlew bootJar --no-daemon
 FROM openjdk:10.0.2-jre
 LABEL maintainer "orekyuu <orekyuu@gmail.com>, nokok <nokok.kz@gmail.com>"
 
-COPY --from=builder /app/build/libs/tuzigiri-0.0.1-SNAPSHOT.jar .
-CMD ["java", "-jar", "tuzigiri-0.0.1-SNAPSHOT.jar"]
+COPY --from=builder /app/build/libs/tuzigiri.jar .
+CMD ["java", "-jar", "tuzigiri.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,6 @@ dependencies {
 processResources.destinationDir = compileJava.destinationDir
 // コンパイルより前にSQLファイルを出力先ディレクトリにコピーするために依存関係を逆転する
 compileJava.dependsOn processResources
+
+archivesBaseName = 'tuzigiri'
+version = null


### PR DESCRIPTION
バージョンが変わるとDockerfileも追従しないといけないので、成果物のファイル名からバージョン名を消してtuzigiri.jarにした