### PR TITLE
タイムゾーンの指定方式を変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./infra/mysql/log:/var/log/mysql
     environment:
       ENV: "local"
+      TZ: "Asia/Tokyo"
   tuzigiri-app:
     build: .
     image: tuzigiri-app:latest

--- a/infra/mysql/Dockerfile
+++ b/infra/mysql/Dockerfile
@@ -14,11 +14,6 @@ ENV MIGRATOR_PASSWORD $MIGRATOR_PASSWORD
 
 ADD ./docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 
-RUN  /usr/bin/mysql_tzinfo_to_sql /usr/share/zoneinfo > /docker-entrypoint-initdb.d/timezone.sql
-
-
-ADD ./timezone.cnf /etc/mysql/mysql.conf.d/
-
 RUN set -x &&\
   sed -e "s/###APP_USER_PASSWORD###/$APP_USER_PASSWORD/g" \
       -e "s/###MIGRATOR_PASSWORD###/$MIGRATOR_PASSWORD/g" \

--- a/infra/mysql/timezone.cnf
+++ b/infra/mysql/timezone.cnf
@@ -1,2 +1,0 @@
-[mysqld]
-default-time-zone = 'Asia/Tokyo'


### PR DESCRIPTION
`/docker-entrypoint-initdb.d` にSQLを登録してデータ投入する方法だと、
SQLのデータ投入よりも前にConfigが先に当たってしまいMySQLが起動できなくなってしまっていた。