### PR TITLE
Domaのバージョンを明示的に設定

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-web')
     compile('org.flywaydb:flyway-core:5.0.7')
     compile('org.seasar.doma.boot:doma-spring-boot-starter:1.1.1')
+    compile('org.seasar.doma:doma:2.19.3')
     compile('org.springframework.security:spring-security-oauth2-client:5.0.8.RELEASE')
     compile('org.springframework.security:spring-security-oauth2-jose:5.1.0.RELEASE')
     runtime('org.springframework.boot:spring-boot-devtools')


### PR DESCRIPTION
`doma-spring-boot`は最新のDomaに依存していないので明示的に`dependency`を書いてあげた方が良い。