### PR TITLE
ビルドのたびにGradleと依存のjarをダウンロードしないようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM openjdk:11-jdk as builder
-
-WORKDIR /app
-ADD . .
-RUN ./gradlew bootJar --no-daemon
-
-FROM openjdk:11-jre
+FROM gradle:jdk11-slim as builder
 LABEL maintainer "orekyuu <orekyuu@gmail.com>, nokok <nokok.kz@gmail.com>"
 
+USER root
+
+WORKDIR /app
+ADD build.gradle build.gradle
+ADD settings.gradle settings.gradle
+RUN gradle resolveDependencies --no-daemon
+
+ADD src src
+
+RUN gradle bootJar --no-daemon
+
+
+FROM adoptopenjdk/openjdk11:jdk-11.28
+
 COPY --from=builder /app/build/libs/tuzigiri.jar .
+
 CMD ["java", "-jar", "tuzigiri.jar"]
+

--- a/build.gradle
+++ b/build.gradle
@@ -47,3 +47,34 @@ compileJava.dependsOn processResources
 
 archivesBaseName = 'tuzigiri'
 version = null
+
+task resolveDependencies {
+    doLast {
+        project.rootProject.allprojects.each { subProject ->
+            subProject.buildscript.configurations.each { configuration ->
+                resolveConfiguration(configuration)
+            }
+            subProject.configurations.each { configuration ->
+                resolveConfiguration(configuration)
+            }
+        }
+    }
+}
+
+void resolveConfiguration(configuration) {
+    if (isResolveableConfiguration(configuration)) {
+        configuration.resolve()
+    }
+}
+
+boolean isResolveableConfiguration(configuration) {
+    def nonResolveableConfigurations = ['apiElements', 'implementation',
+                                        'runtimeElements', 'runtimeOnly',
+                                        'testImplementation', 'testRuntimeOnly',
+                                        'generatedImplementation', 'generatedRuntimeOnly']
+
+    if (nonResolveableConfigurations.contains(configuration.getName())) {
+        return false
+    }
+    return true
+}


### PR DESCRIPTION
Gradle側で依存関係の解決だけ先にやるようにした(多分)
依存関係の解決とかとソースコードのビルドをするDockerのビルドするレイヤーを分けてビルド時間の短縮化を図った(つもり)